### PR TITLE
MMX on RDKB

### DIFF
--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -92,10 +92,10 @@ endif
 all: $(SRC_LUACONFIG) $(SRC_GENUTILS) $(PROG_LUACONFIG) $(PROG_GENUTILS)
 
 $(PROG_LUACONFIG): $(OBJ_LUACONFIG)
-	$(CC) $(OBJ_LUACONFIG) $(LDFLAGS) $(LUACONFIG_LIBS) -o $@
+	$(CC) -Wl,-soname,$@ $(OBJ_LUACONFIG) $(LDFLAGS) $(LUACONFIG_LIBS) -o $@
 
 $(PROG_GENUTILS): $(OBJ_GENUTILS) $(HW_BINARIES)
-	$(CC) $(OBJ_GENUTILS) $(LDFLAGS) -o $@
+	$(CC) -Wl,-soname,$@ $(OBJ_GENUTILS) $(LDFLAGS) -o $@
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/include

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -70,9 +70,7 @@
 
 .PHONY: all clean
 
-CURDIR := $(shell pwd)
-
-override CFLAGS += -c -std=c99 -fPIC -Wall -Wextra -Wpedantic -I$(CURDIR)
+override CFLAGS += -c -std=c99 -fPIC -Wall -Wextra -Wpedantic
 override LDFLAGS += -shared -fPIC -llua
 
 LUACONFIG_LIBS=-lconfig
@@ -81,7 +79,7 @@ PROG_LUACONFIG=lualibconfig.so
 PROG_GENUTILS=libing-gen-utils.so
 
 SRC_ALL:=$(wildcard *.c)
-SRC_LUACONFIG:=$(wildcard $(CURDIR)/lualibconfig.c)
+SRC_LUACONFIG:=$(wildcard lualibconfig.c)
 SRC_GENUTILS:=$(filter-out $(SRC_LUACONFIG),$(SRC_ALL))
 
 OBJ_LUACONFIG:=$(SRC_LUACONFIG:.c=.o)

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -89,6 +89,8 @@ ifeq ($(PREFIX),)
     PREFIX := /usr
 endif
 
+override LUAPATH ?= $(PREFIX)/lib/lua
+
 all: $(SRC_LUACONFIG) $(SRC_GENUTILS) $(PROG_LUACONFIG) $(PROG_GENUTILS)
 
 $(PROG_LUACONFIG): $(OBJ_LUACONFIG)
@@ -104,8 +106,8 @@ install:
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 644 $(PROG_GENUTILS) $(DESTDIR)$(PREFIX)/lib/
 
-	install -d  $(DESTDIR)$(PREFIX)/lib/lua/mmx
-	install -m 644 $(PROG_LUACONFIG) $(DESTDIR)$(PREFIX)/lib/lua/mmx/
+	install -d  $(DESTDIR)$(LUAPATH)/mmx
+	install -m 644 $(PROG_LUACONFIG) $(DESTDIR)$(LUAPATH)/mmx/
 
 clean:
 	rm -f $(OBJ_LUACONFIG) $(PROG_LUACONFIG) $(OBJ_GENUTILS) $(PROG_GENUTILS)

--- a/src/lua/Makefile
+++ b/src/lua/Makefile
@@ -72,12 +72,14 @@ ifeq ($(PREFIX),)
     PREFIX := /usr
 endif
 
+override LUAPATH ?= $(PREFIX)/lib/lua
+
 all:
 	echo "Nothing to compile"
 
 install:
-	install -d $(DESTDIR)$(PREFIX)/lib/lua/mmx
-	install -m 644 *.lua $(DESTDIR)$(PREFIX)/lib/lua/mmx/
+	install -d $(DESTDIR)$(LUAPATH)/mmx
+	install -m 644 *.lua $(DESTDIR)$(LUAPATH)/mmx/
 
 clean:
 	echo "Nothing to clean"


### PR DESCRIPTION
# Add SONAME field into shared libraries
    
    To be able build this library with Yocto it's needed to add SONAME
    into shared library to allow detect that recipe really provides
    library
    
# Fix unneeded libluaconfig.o presense in libing-gen-utils.so linking
    
    CURDIR variable with absolute path to src/c folder is used on add
    libluaconfig.c into SRC_LUACONFIG list.
    
    Because of absolute path it cannot be filtered and "libluaconfig.o"
    present in libing-gen-utils.so.
    That cause linking error for packages depends on libing-gen-utils
    but not linked libconfig explicitly
    
    Remove CURDIR variable usage

Closes #1 